### PR TITLE
Fix failing test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install: 
     - pip install --upgrade pip
     - pip install -q six
+    - pip install virtualenv
 script: python tests.py
 branches:
     only:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ setup(
     description='An API for virtualenv/pip',
     long_description='README.rst',
     url='https://github.com/sjkingo/virtualenv-api',
-    install_requires=['six'],
+    install_requires=['six',
+                      'virtualenv'
+                      ],
     packages=find_packages(),
 )

--- a/tests.py
+++ b/tests.py
@@ -91,13 +91,13 @@ class BaseTest(TestCase):
         self.assertIsInstance(result, dict)
         self.assertTrue(bool(result))
         if result:
-            self.assertIn(pack, [k.lower() for k in result.keys()])
+            self.assertIn(pack, [k.split(' (')[0].lower() for k in result.keys()])
 
     def test_search_names(self):
         pack = packages_for_tests[0].lower()
         result = self.virtual_env_obj.search_names(pack)
         self.assertIsInstance(result, list)
-        self.assertIn(pack, [k.lower() for k in result])
+        self.assertIn(pack, [k.split(' (')[0].lower() for k in result])
 
     def tearDown(self):
         if os.path.exists(self.env_path) and self.__class__.env_path is None:

--- a/virtualenvapi/manage.py
+++ b/virtualenvapi/manage.py
@@ -44,6 +44,16 @@ class VirtualEnvironment(object):
         return os.path.join('bin', 'pip')
 
     @property
+    def pip_version(self):
+        """Version of installed pip."""
+        if not self._pip_exists:
+            return None
+        if not hasattr(self, '_pip_version'):
+            string_version = self._execute([self._pip_rpath, '-V']).split()[1]
+            self._pip_version = tuple([int(n) for n in string_version.split('.')])
+        return self._pip_version
+
+    @property
     def root(self):
         """The root directory that this virtual environment exists in."""
         return os.path.split(self.path)[0]
@@ -272,8 +282,9 @@ class VirtualEnvironment(object):
         List of all packages that are installed in this environment in
         the format [(name, ver), ..].
         """
+        freeze_options = ['-l', '--all'] if self.pip_version >= (8, 1, 0) else ['-l']
         return list(map(split_package_name, filter(None, self._execute(
-                [self._pip_rpath, 'freeze', '-l']).split(linesep))))
+                [self._pip_rpath, 'freeze'] + freeze_options).split(linesep))))
 
     @property
     def installed_package_names(self):


### PR DESCRIPTION
This PR solves issues in tests suite:
- parse names from pip search output in test.py
- add --all flag to pip freeze if pip version is >= 8.1.0
  wheel is excluded from pip freeze output if --all option is not specified: https://github.com/pypa/pip/releases/tag/8.1.0