### PR TITLE
This fixes an AttributeError

### DIFF
--- a/virtualenvapi/manage.py
+++ b/virtualenvapi/manage.py
@@ -114,7 +114,7 @@ class VirtualEnvironment(object):
             prog = args[0]
             if prog[0] != os.sep:
                 prog = os.path.join(self.path, prog)
-            raise OSError('%s: %s' % (prog, six.u(e)))
+            raise OSError('%s: %s' % (prog, six.u(e.message)))
         except subprocess.CalledProcessError as e:
             output, error = e.output
             e.output = output


### PR DESCRIPTION
AttributeError: 'exceptions.OSError' object has no attribute 'replace'

```
'exceptions.OSError' object has no attribute 'replace'
 Traceback (most recent call last):
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/bats/app.py", line 165, in test_command
     exit_code = command.run(args)
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/bats/commands/plugin/install.py", line 27, in run
     venv.install(args.package)
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/virtualenvapi/manage.py", line 179, in install
     if not (force or upgrade) and self.is_installed(package_args[-1]):
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/virtualenvapi/manage.py", line 247, in is_installed
     return pkg_tuple[0] in self.installed_package_names
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/virtualenvapi/manage.py", line 301, in installed_package_names
     return [name.lower() for name, _ in self.installed_packages]
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/virtualenvapi/manage.py", line 294, in installed_packages
     freeze_options = ['-l', '--all'] if self.pip_version >= (8, 1, 0) else ['-l']
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/virtualenvapi/manage.py", line 57, in pip_version
     string_version = self._execute([self._pip_rpath, '-V']).split()[1]
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/virtualenvapi/manage.py", line 117, in _execute
     raise OSError('%s: %s' % (prog, six.u(e)))
   File "/var/lib/jenkins/workspace/python-build/python-tgt-bats/python-tgt-bats-mergepull@2/.tox/py27/lib/python2.7/site-packages/six.py", line 647, in u
     return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
 AttributeError: 'exceptions.OSError' object has no attribute 'replace'
```