### PR TITLE
add support for system-site-packages option for creating a virtualenv

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -164,6 +164,22 @@ class EnvironmentTest(BaseTest):
         return env_path
 
 
+class SystemSitePackagesTest(TestCase):
+    """
+    test coverage for using system-site-packages flag
+    """
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        if os.path.exists(self.dir):
+            shutil.rmtree(self.dir)
+
+    def test_system_site_packages(self):
+        venv = VirtualEnvironment(self.dir, system_site_packages=True)
+        venv._create()
+
+
 if __name__ == '__main__':
     # ToDo refactoring
     if len(sys.argv) == 2 and sys.argv[1].startswith('--env='):


### PR DESCRIPTION
Added API support for using the --system-site-packages flag in the virtualenv, this can be helpful when sharing large packages like pandas among several virtualenvs. 
There is test coverage for it although its hard to verify the outcome in the test without having more details of the underlying system python. 

Example:

```python
from virtualenvapi.manage import VirtualEnvironment
venv = VirtualEnvironment("./test-venv", system_site_packages=True)
venv.open_or_create()   
```
