### PR TITLE
add support for installing packages from pip requirements file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,13 @@ pip’s package syntax (e.g. ``django==1.4``) or as a tuple of ``('name',
 
     >>> env.install('-e git+https://github.com/stephenmcd/cartridge.git')
 
+- Packages in a pip requirements file can be installed be prefixing the
+  requirements file path with `-r`:
+
+.. code:: python
+
+    >>> env.install('-r requirements.txt')
+
 -  Instances of the environment provide an ``installed_packages``
    property:
 

--- a/tests.py
+++ b/tests.py
@@ -71,6 +71,25 @@ class BaseTest(TestCase):
             self.virtual_env_obj.install(pack)
             self.assertTrue(self.virtual_env_obj.is_installed(pack))
 
+    def test_install_requirements(self):
+        """test installing Python packages from a pip requirements file"""
+        self._uninstall_packages(packages_for_tests)
+
+        # create a temporary requirements.txt file with some packages
+        with tempfile.NamedTemporaryFile(delete=False) as tmp_requirements_file:
+            tmp_requirements_file.write('\n'.join(packages_for_tests))
+            tmp_requirements_file_path = tmp_requirements_file.name
+
+        try:
+            self.virtual_env_obj.install('-r {}'.format(tmp_requirements_file_path))
+
+            for pack in packages_for_tests:
+                self.assertTrue(self.virtual_env_obj.is_installed(pack))
+
+        finally:
+            # ensure temp requirements file is always deleted
+            os.remove(tmp_requirements_file_path)
+
     def test_uninstall(self):
         self._install_packages(packages_for_tests)
         for pack in packages_for_tests:

--- a/tests.py
+++ b/tests.py
@@ -76,7 +76,7 @@ class BaseTest(TestCase):
         self._uninstall_packages(packages_for_tests)
 
         # create a temporary requirements.txt file with some packages
-        with tempfile.NamedTemporaryFile(delete=False) as tmp_requirements_file:
+        with tempfile.NamedTemporaryFile('w', delete=False) as tmp_requirements_file:
             tmp_requirements_file.write('\n'.join(packages_for_tests))
             tmp_requirements_file_path = tmp_requirements_file.name
 

--- a/virtualenvapi/manage.py
+++ b/virtualenvapi/manage.py
@@ -192,6 +192,8 @@ class VirtualEnvironment(object):
          'Django'
          'Django==1.5'
          ('Django', '1.5')
+         '-e .'
+         '-r requirements.txt'
 
         If `force` is True, force an installation. If `upgrade` is True,
         attempt to upgrade the package in question. If both `force` and
@@ -204,11 +206,11 @@ class VirtualEnvironment(object):
             options = []
         if isinstance(package, tuple):
             package = '=='.join(package)
-        if package.startswith('-e'):
+        if package.startswith(('-e', '-r')):
             package_args = package.split()
         else:
             package_args = [package]
-        if not (force or upgrade) and self.is_installed(package_args[-1]):
+        if not (force or upgrade) and (package_args[0] != '-r' and self.is_installed(package_args[-1])):
             self._write_to_log('%s is already installed, skipping (use force=True to override)' % package_args[-1])
             return
         if not isinstance(options, list):


### PR DESCRIPTION
Added support for installing Python packages defined in a [pip requirements file](https://pip.readthedocs.io/en/latest/user_guide/#requirements-files). This is very useful for projects that define Python package versions in a (or multiple) requirements files.

example:
```py
env = VirtualEnvironment('./venv')
env.install('-r requirements.txt')
```