### PR TITLE
Blacklist __PYVENV_LAUNCHER__ env var in subprocess calls

### DIFF
--- a/virtualenvapi/manage.py
+++ b/virtualenvapi/manage.py
@@ -29,6 +29,11 @@ class VirtualEnvironment(object):
         self.path = os.path.abspath(os.path.expanduser(path))
 
         self.env = environ.copy()
+
+        # Blacklist environment variables that will break pip in virtualenvs
+        # See https://github.com/pypa/virtualenv/issues/845
+        self.env.pop('__PYVENV_LAUNCHER__', None)
+
         if cache is not None:
             self.env['PIP_DOWNLOAD_CACHE'] = os.path.expanduser(os.path.expandvars(cache))
 


### PR DESCRIPTION
I encountered a weird bug in which the shebang in any binaries created using `venv.install` points to the wrong Python path, instead of the Python binary created within the virtualenv. It also seems that this bug is specific to macOS, or maybe just to Homebrew installs of Python.

If I do the following:

```sh
$ python
>>> from virtualenvapi import VirtualEnvironment
>>> env = VirtualEnvironment('.venv')
>>> env.install('yapf')
>>> ^D
$ head -n1 .venv/bin/yapf
#!/usr/local/Cellar/python/3.7.6_1/bin/python3.7
$ source .venv/bin/activate
$ yapf
Traceback (most recent call last):
  File "/Users/irvin/Projects/dotfiles/.venv/bin/yapf", line 5, in <module>
    from yapf import run_main
ModuleNotFoundError: No module named 'yapf'
```

Since `yapf` is not installed in the Homebrew Python's environment (based on the shebang), we get a ModuleNotFoundError.

See https://github.com/pypa/virtualenv/issues/845 for more details. It seems that this is a bug in CPython/pip itself (supposed fix at https://github.com/python/cpython/pull/9516), but there hasn't been movement on either CPython or pip to fix it.

Either way, blacklisting the `__PYVENV_LAUNCHER__` environment variable before calling `subprocess.Popen` seems to be the fix adopted by most people in the interim; see https://github.com/theacodes/nox/pull/49 for an example.