### PR TITLE
Remove search test cases

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -96,26 +96,6 @@ class InstalledTestCase(TestBase):
             self.assertTrue(self.virtual_env_obj.is_installed(pack))
 
 
-class SearchTestCase(TestBase):
-    """
-    Test pip search.
-    """
-
-    def test_search(self):
-        for pack in all_packages_for_tests:
-            result = self.virtual_env_obj.search(pack)
-            self.assertIsInstance(result, dict)
-            self.assertTrue(bool(result))
-            if result:
-                self.assertIn(pack.lower(), [k.split(' (')[0].lower() for k in result.keys()])
-
-    def test_search_names(self):
-        for pack in all_packages_for_tests:
-            result = self.virtual_env_obj.search_names(pack)
-            self.assertIsInstance(result, list)
-            self.assertIn(pack.lower(), [k.split(' (')[0].lower() for k in result])
-
-
 class PythonArgumentTestCase(TestBase):
     """
     Test passing a different interpreter path to `VirtualEnvironment` (`virtualenv -p`).


### PR DESCRIPTION
Hello.

`pip search` API was disabled in December 2020 because of a lot of performance issues:
https://github.com/pypa/pip/issues/5216#issuecomment-744605466

So tests cases using this feature are also failing now. It's time to remove them.
But other repo implementations which are compatible with PyPI API were not affected, e.g. Nexus or Artifactory installations. Because of that let's keep the `.search` method in the package. At least until `pip search` command will be removed completely.