### PR TITLE
Fix `--system-site-packages` tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -149,13 +149,6 @@ class SystemSitePackagesTest(unittest.TestCase):
         snapshot system package list
         """
         self.dir = tempfile.mkdtemp()
-        self.no_global = (
-            "lib/python{}.{}"
-            "/no-global-site-packages.txt"
-        ).format(
-            sys.version_info.major,
-            sys.version_info.minor
-        )
 
     def tearDown(self):
         if os.path.exists(self.dir):
@@ -164,30 +157,50 @@ class SystemSitePackagesTest(unittest.TestCase):
     def test_system_site_packages(self):
         """
         test that creating a venv with system_site_packages=True
-        results in a venv that does not contain the no-global-site-packages file
-
+        results in a venv that does not have system packages installed
         """
+
         venv = VirtualEnvironment(self.dir, system_site_packages=True)
-        venv._create()
-        expected = os.path.join(venv.path, self.no_global)
-        self.assertTrue(
-            not os.path.exists(expected)
-        )
+        venv.open_or_create()
+
+        # always installed and accessible
+        self.assertTrue(venv.is_installed("pip"))
+        self.assertTrue(venv.is_installed("wheel"))
+        self.assertTrue(venv.is_installed("setuptools"))
+        self.assertTrue(venv.is_accessible("pip"))
+        self.assertTrue(venv.is_accessible("wheel"))
+        self.assertTrue(venv.is_accessible("setuptools"))
+
+        # system packages are not listed with -l option
+        self.assertFalse(venv.is_installed("six"))
+        self.assertFalse(venv.is_installed("virtualenv"))
+
+        # but they are accessible
+        self.assertTrue(venv.is_accessible("six"))
+        self.assertTrue(venv.is_accessible("virtualenv"))
 
     def test_no_system_site_packages(self):
         """
         test that creating a venv with system_site_packages=False
-        results in a venv that contains the no-global-site-packages
-        file
-
+        results in a venv that does not have system packages installed
         """
-        venv = VirtualEnvironment(self.dir)
-        venv._create()
-        expected = os.path.join(venv.path, self.no_global)
-        self.assertTrue(
-            os.path.exists(expected)
-        )
 
+        venv = VirtualEnvironment(self.dir)
+        venv.open_or_create()
+
+        # always installed and accessible
+        self.assertTrue(venv.is_installed("pip"))
+        self.assertTrue(venv.is_installed("wheel"))
+        self.assertTrue(venv.is_installed("setuptools"))
+        self.assertTrue(venv.is_accessible("pip"))
+        self.assertTrue(venv.is_accessible("wheel"))
+        self.assertTrue(venv.is_accessible("setuptools"))
+
+        # system packages are not accessible
+        self.assertFalse(venv.is_installed("six"))
+        self.assertFalse(venv.is_installed("virtualenv"))
+        self.assertFalse(venv.is_accessible("six"))
+        self.assertFalse(venv.is_accessible("virtualenv"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since January 2020 virtualenv package was completely rewritten (v20+). It does not create `no-global-site-packages.txt` file anymore, that's why tests are failing now.

In this PR I've added few new methods: `is_accessible`, `all_packages`, `all_package_names`.
They are working just like the existing `is_installed`, `installed_packages`, `installed_package_names`, but they do not use `-l` flag while calling `pip freeze`. This allows to get the list of all packages which are available in the current virtualenv including system ones.

IMHO, it's better than parse new config file type generated by latest `virtualenv` version.