### PR TITLE
Filter out comments from `pip freeze` output

### DIFF
--- a/virtualenvapi/manage.py
+++ b/virtualenvapi/manage.py
@@ -329,8 +329,11 @@ class VirtualEnvironment(object):
         the format [(name, ver), ..].
         """
         freeze_options = ['-l', '--all'] if self.pip_version >= (8, 1, 0) else ['-l']
-        return list(map(split_package_name, filter(None, self._execute_pip(
-                ['freeze'] + freeze_options).split(linesep))))
+        filtered = self._execute_pip(['freeze'] + freeze_options).split(linesep)
+        filtered = filter(None, filtered)
+        # Remove any comments in the `pip freeze` output
+        filtered = filter(lambda s: not s.startswith('#'), filtered)
+        return list(map(split_package_name, filtered))
 
     @property
     def installed_package_names(self):


### PR DESCRIPTION
I noticed that sometimes the `pip freeze` output can return comments, which can yield weird results when querying the `installed_packages`.

I'm not sure if there are other cases, but this definitely happens if you make an editable install with `ve.install("-e blah/")`. You get a comment like `# Editable install with no version control (ansible-core and 2.11.5)` in the `pip freeze` output.