### PR TITLE
Always use the current interpreter for test_python_version

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -123,7 +123,7 @@ class PythonArgumentTestCase(TestBase):
 
     def setUp(self):
         self.env_path = tempfile.mkdtemp()
-        self.python = which('python')
+        self.python = sys.executable
         self.assertIsNotNone(self.python)
         self.virtual_env_obj = VirtualEnvironment(self.env_path, python=self.python)
 


### PR DESCRIPTION
Instead of searching the `PATH` for `python`, use `sys.executable` to get the Python interpreter parameter for the virtual environment in this test. This keeps the test from failing in environments where there is no `python` on the `PATH`, e.g. on Fedora Linux where only `python3` is present in the RPM build environment (without the `python-unversioned-command` package).